### PR TITLE
feat: Allow custom OpenAI API base URL via environment variable

### DIFF
--- a/src/app/api/images/route.ts
+++ b/src/app/api/images/route.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
+  baseURL: process.env.OPENAI_API_BASE_URL,
 });
 
 const outputDir = path.resolve(process.cwd(), 'generated-images');


### PR DESCRIPTION
        Hi there,

        I needed to use this project with a custom OpenAI-compatible API endpoint, so I've added the ability to configure the base URL.

        **Changes:**

        *   Modified `src/app/api/images/route.ts` to read the `baseURL` from the `OPENAI_API_BASE_URL` environment variable when initializing the OpenAI client.
        *   If `OPENAI_API_BASE_URL` is not set, it defaults to the standard OpenAI URL, so existing behavior is unchanged.

        **How to use:**

        Set the `OPENAI_API_BASE_URL` environment variable to the desired endpoint URL (e.g., `https://api.voidai.xyz/v1`). The `OPENAI_API_KEY` variable still needs to be set as usual.

        Thanks. It's my first contribution so I hope it's right. 