### PR TITLE
feat(image): show elapsed time during generation and edit

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -71,6 +71,7 @@ export default function HomePage() {
     const [isPasswordRequiredByBackend, setIsPasswordRequiredByBackend] = React.useState<boolean | null>(null);
     const [clientPasswordHash, setClientPasswordHash] = React.useState<string | null>(null);
     const [isLoading, setIsLoading] = React.useState(false);
+    const [generationStartTime, setGenerationStartTime] = React.useState<number | null>(null);
     const [isSendingToEdit, setIsSendingToEdit] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
     const [latestImageBatch, setLatestImageBatch] = React.useState<{ path: string; filename: string }[] | null>(null);
@@ -338,6 +339,7 @@ export default function HomePage() {
         let durationMs = 0;
 
         setIsLoading(true);
+        setGenerationStartTime(startTime);
         setError(null);
         setLatestImageBatch(null);
         setImageOutputView('grid');
@@ -686,6 +688,7 @@ export default function HomePage() {
         } finally {
             if (durationMs === 0) durationMs = Date.now() - startTime;
             setIsLoading(false);
+            setGenerationStartTime(null);
         }
     };
 
@@ -1007,6 +1010,7 @@ export default function HomePage() {
                             onViewChange={setImageOutputView}
                             altText='Generated image output'
                             isLoading={isLoading || isSendingToEdit}
+                            loadingStartTime={generationStartTime}
                             onSendToEdit={handleSendToEdit}
                             currentMode={mode}
                             baseImagePreviewUrl={editSourceImagePreviewUrls[0] || null}

--- a/src/components/image-output.tsx
+++ b/src/components/image-output.tsx
@@ -4,6 +4,16 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { Loader2, Send, Grid } from 'lucide-react';
 import Image from 'next/image';
+import * as React from 'react';
+
+function ElapsedTimer({ startTime, className }: { startTime: number; className?: string }) {
+    const [now, setNow] = React.useState(() => Date.now());
+    React.useEffect(() => {
+        const id = setInterval(() => setNow(Date.now()), 100);
+        return () => clearInterval(id);
+    }, []);
+    return <span className={cn('tabular-nums', className)}>{Math.max(0, (now - startTime) / 1000).toFixed(1)}s</span>;
+}
 
 type ImageInfo = {
     path: string;
@@ -16,6 +26,7 @@ type ImageOutputProps = {
     onViewChange: (view: 'grid' | number) => void;
     altText?: string;
     isLoading: boolean;
+    loadingStartTime: number | null;
     onSendToEdit: (filename: string) => void;
     currentMode: 'generate' | 'edit';
     baseImagePreviewUrl: string | null;
@@ -35,6 +46,7 @@ export function ImageOutput({
     onViewChange,
     altText = 'Generated image output',
     isLoading,
+    loadingStartTime,
     onSendToEdit,
     currentMode,
     baseImagePreviewUrl,
@@ -79,6 +91,9 @@ export function ImageOutput({
                             <div className='absolute bottom-4 left-1/2 flex -translate-x-1/2 items-center gap-2 rounded-full bg-black/70 px-3 py-1.5 text-white/80'>
                                 <Loader2 className='h-4 w-4 animate-spin' />
                                 <p className='text-sm'>Streaming...</p>
+                                {loadingStartTime !== null && (
+                                    <ElapsedTimer startTime={loadingStartTime} className='text-sm text-white/50' />
+                                )}
                             </div>
                         </div>
                     ) : currentMode === 'edit' && baseImagePreviewUrl ? (
@@ -94,12 +109,18 @@ export function ImageOutput({
                             <div className='absolute inset-0 flex flex-col items-center justify-center bg-black/50 text-white/80'>
                                 <Loader2 className='mb-2 h-8 w-8 animate-spin' />
                                 <p>Editing image...</p>
+                                {loadingStartTime !== null && (
+                                    <ElapsedTimer startTime={loadingStartTime} className='mt-1 text-sm text-white/50' />
+                                )}
                             </div>
                         </div>
                     ) : (
                         <div className='flex flex-col items-center justify-center text-white/60'>
                             <Loader2 className='mb-2 h-8 w-8 animate-spin' />
                             <p>Generating image...</p>
+                            {loadingStartTime !== null && (
+                                <ElapsedTimer startTime={loadingStartTime} className='mt-1 text-sm text-white/40' />
+                            )}
                         </div>
                     )
                 ) : imageBatch && imageBatch.length > 0 ? (


### PR DESCRIPTION
## What

Adds a live elapsed-time counter to the output panel while an image is generating or being edited, so you can see how long the request has been running.

Closes #26.

## How

- Track a single `generationStartTime` timestamp in `page.tsx`, set when an API call starts and cleared when it finishes. It is intentionally not set for the "send to edit" copy, which shows the spinner but is not a generation.
- A small `ElapsedTimer` component ticks every 100ms and renders `12.3s` (`tabular-nums` keeps the width from jittering).
- Rendered in all three loading states in `image-output.tsx`: streaming preview pill, edit overlay, and the plain generating view.

Because the start time lives in the parent, the count climbs smoothly across the generate to streaming branch switch instead of resetting.

<p align="center"><em>what it looks like (sped up)</em></p>
<p align="center">
  <img width="428" height="444" alt="generation-timer" src="https://github.com/user-attachments/assets/971b1549-fd8d-4ab3-a96d-fc3ed43127b0" />
</p>
